### PR TITLE
Move 'forceLowerCase' to options - fixes #12

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,11 @@ const ansi = require('ansi-escapes')
 const chalk = require('chalk')
 
 module.exports = (
-  { start = '', suggestions = [], suggestionColor = 'gray' } = {}
+  { forceLowerCase = false, start = '', suggestions = [], suggestionColor = 'gray' } = {}
 ) => {
   return new Promise((resolve, reject) => {
     const { stdout, stdin } = process
     const isRaw = stdin.isRaw
-    const forceLowerCase = true
     const abortChars = new Set(['\u0003'])
     const resolveChars = new Set(['\r'])
     const autoCompleteChars = new Set([


### PR DESCRIPTION
Addresses my issue regarding case sensitivity. This would simply add the flag to the options, defaulting to case-sensitive, which I would feel to be the most sensible value. If you disagree I'd be more than happy to change it back to default-lowercase if it meant getting this PR through. I plan to use this project quite heavily in a CLI for [Buttercup.pw](https://buttercup.pw).